### PR TITLE
Add standard "About Ably" info to all public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Ably JSON Patch data service demo
 
-This is a JSON Patch demo for [Ably Realtime, a realtime Data Streaming Network](https://www.ably.io).
+_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/documentation)._
+
+This is a JSON Patch demo for Ably.
 
 At Ably, many of our customers use our platform to push updates to a data object to any number of clients. For example, this could be a score board during a live football match, and customers rely on Ably to provide the limitless scale, reliability and low latency for each update published.
 


### PR DESCRIPTION
## Description

Add standard "About Ably" info to all public repos

* [DOC-197](https://ably.atlassian.net/browse/DOC-197).

## Review

Please check the intro section to the README:
:
* [README](README.md)